### PR TITLE
feat: add links functionality to questions and answers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ gem "devise"
 
 gem "tailwindcss-rails"
 
+# Use cocoon for nested forms
+gem "cocoon"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cocoon (1.2.15)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -412,6 +413,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  cocoon
   debug
   devise
   factory_bot_rails

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -74,7 +74,11 @@ class AnswersController < ApplicationController
 
   # Permitted parameters
   def answer_params
-    params.require(:answer).permit(:body, files: [])
+    params.require(:answer).permit(
+      :body, 
+      files: [], 
+      links_attributes: [:id, :name, :url, :_destroy]
+    )
   end
 
   # Check if current user is the author of the answer

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,0 +1,29 @@
+class LinksController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_link
+  before_action :check_author
+
+  def destroy
+    @link.destroy
+    
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back(fallback_location: root_path) }
+    end
+  end
+
+  private
+
+  def set_link
+    @link = Link.find(params[:id])
+  end
+
+  def check_author
+    unless current_user.author_of?(@link.linkable)
+      respond_to do |format|
+        format.turbo_stream { head :forbidden }
+        format.html { redirect_to root_path, alert: 'Вы не можете удалить эту ссылку' }
+      end
+    end
+  end
+end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -70,7 +70,12 @@ class QuestionsController < ApplicationController
 
   # Permitted parameters
   def question_params
-    params.require(:question).permit(:title, :body, files: [])
+    params.require(:question).permit(
+      :title, 
+      :body, 
+      files: [], 
+      links_attributes: [:id, :name, :url, :_destroy]
+    )
   end
 
   # Check if current user is the author of the question

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,27 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "flowbite"
+import "@nathanvda/cocoon"
+
+// Инициализация Cocoon для динамических вложенных форм
+document.addEventListener("turbo:load", function() {
+  document.addEventListener('click', function(e) {
+    if (e.target && e.target.matches('.add_fields')) {
+      e.preventDefault();
+      const time = new Date().getTime();
+      const regexp = new RegExp(e.target.dataset.id, 'g');
+      const template = e.target.dataset.fieldsTemplate;
+      const newFields = template.replace(regexp, time);
+      e.target.insertAdjacentHTML('beforebegin', newFields);
+    }
+    
+    if (e.target && e.target.matches('.remove_fields')) {
+      e.preventDefault();
+      const wrapper = e.target.closest('.nested-fields');
+      if (wrapper.querySelector('input[type=hidden][name*=_destroy]')) {
+        wrapper.querySelector('input[type=hidden][name*=_destroy]').value = '1';
+      }
+      wrapper.style.display = 'none';
+    }
+  });
+});

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -2,6 +2,9 @@ class Answer < ApplicationRecord
   # Associations
   belongs_to :question
   belongs_to :user
+  has_many :links, dependent: :destroy, as: :linkable
+  
+  accepts_nested_attributes_for :links, reject_if: :all_blank, allow_destroy: true
   has_many_attached :files
 
   # Callbacks

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,0 +1,26 @@
+class Link < ApplicationRecord
+  belongs_to :linkable, polymorphic: true
+
+  validates :name, presence: true
+  validates :url, presence: true
+  validate :validate_url_format
+
+  def gist?
+    url.present? && url.match?(%r{^https://gist\.github\.com/})
+  end
+
+  def gist_id
+    return nil unless gist?
+    
+    url.split('/').last
+  end
+
+  private
+
+  def validate_url_format
+    return if url.blank?
+    return if url.start_with?('http://', 'https://')
+    
+    errors.add(:url, 'должен быть валидным URL, начинающимся с http:// или https://')
+  end
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -3,6 +3,9 @@ class Question < ApplicationRecord
   belongs_to :user
   has_many :answers, dependent: :destroy
   has_one :best_answer, -> { where(best: true) }, class_name: "Answer"
+  has_many :links, dependent: :destroy, as: :linkable
+  
+  accepts_nested_attributes_for :links, reject_if: :all_blank, allow_destroy: true
   has_many_attached :files
 
   # Callbacks

--- a/app/views/answers/_answer.html.erb
+++ b/app/views/answers/_answer.html.erb
@@ -17,6 +17,15 @@
         <p class="text-gray-700 dark:text-gray-300"><%= simple_format(answer.body) %></p>
       </div>
       
+      <% if answer.links.present? %>
+      <div class="p-4 mb-4 rounded-lg bg-gray-50 dark:bg-gray-800">
+        <h3 class="text-base font-medium mb-3 text-gray-900 dark:text-white">Ссылки:</h3>
+        <div class="links">
+          <%= render answer.links %>
+        </div>
+      </div>
+      <% end %>
+      
       <% if answer.files.attached? %>
       <div class="p-4 mb-4 rounded-lg bg-gray-50 dark:bg-gray-800">
         <h3 class="text-base font-medium mb-3 text-gray-900 dark:text-white">Attached Files:</h3>

--- a/app/views/answers/_form.html.erb
+++ b/app/views/answers/_form.html.erb
@@ -22,6 +22,25 @@
       <%= form.label :body, "Edit your answer", class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" %>
       <%= form.text_area :body, rows: 6, class: "w-full px-4 py-3 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus-ring dark:bg-gray-700 dark:border-gray-600 dark:text-white resize-y" %>
     </div>
+    
+    <div class="links mb-5">
+      <h3 class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Ссылки</h3>
+      
+      <div id="links">
+        <%= form.fields_for :links do |link| %>
+          <%= render 'links/link_fields', f: link %>
+        <% end %>
+      </div>
+      
+      <div class="mt-3">
+        <%= link_to 'Добавить ссылку', '#', 
+            class: 'add_fields text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800 focus-ring',
+            data: { 
+              id: 'new_link_fields', 
+              fields_template: fields_for('answer[links_attributes][new_link_fields]', Link.new, child_index: 'new_link_fields') { |builder| render('links/link_fields', f: builder) }.gsub('\n', '') 
+            } %>
+      </div>
+    </div>
 
     <div class="mb-5">
       <%= form.label :files, class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" %>
@@ -83,6 +102,25 @@
     <div class="mb-5">
       <%= form.text_area :body, rows: 6, placeholder: "Write your answer here...", 
           class: "w-full px-4 py-3 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus-ring dark:bg-gray-700 dark:border-gray-600 dark:text-white resize-y" %>
+    </div>
+    
+    <div class="links mb-5">
+      <h3 class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Ссылки</h3>
+      
+      <div id="links">
+        <%= form.fields_for :links do |link| %>
+          <%= render 'links/link_fields', f: link %>
+        <% end %>
+      </div>
+      
+      <div class="mt-3">
+        <%= link_to 'Добавить ссылку', '#', 
+            class: 'add_fields text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800 focus-ring',
+            data: { 
+              id: 'new_link_fields', 
+              fields_template: fields_for('answer[links_attributes][new_link_fields]', Link.new, child_index: 'new_link_fields') { |builder| render('links/link_fields', f: builder) }.gsub('\n', '') 
+            } %>
+      </div>
     </div>
 
     <div class="mb-5">

--- a/app/views/links/_link.html.erb
+++ b/app/views/links/_link.html.erb
@@ -1,0 +1,28 @@
+<div class="link mb-2" id="link-<%= link.id %>">
+  <% if link.gist? %>
+    <div class="gist mb-2">
+      <div class="flex items-center justify-between">
+        <h4 class="text-sm font-medium text-gray-900 dark:text-white"><%= link.name %></h4>
+        <% if current_user&.author_of?(link.linkable) %>
+          <%= link_to '✕', link_path(link), 
+              data: { turbo_method: :delete, turbo_confirm: 'Вы уверены?' },
+              class: "text-red-600 hover:text-red-800 dark:text-red-500 dark:hover:text-red-400" %>
+        <% end %>
+      </div>
+      <script src="<%= link.url %>.js"></script>
+    </div>
+  <% else %>
+    <div class="flex items-center justify-between p-2 border border-gray-200 rounded-lg dark:border-gray-700">
+      <div class="flex items-center">
+        <span class="text-sm text-gray-700 dark:text-gray-300">
+          <%= link.name %>: <%= link_to link.url, link.url, target: "_blank", class: "text-blue-600 hover:underline dark:text-blue-500" %>
+        </span>
+      </div>
+      <% if current_user&.author_of?(link.linkable) %>
+        <%= link_to '✕', link_path(link), 
+            data: { turbo_method: :delete, turbo_confirm: 'Вы уверены?' },
+            class: "text-red-600 hover:text-red-800 dark:text-red-500 dark:hover:text-red-400" %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/links/_link_fields.html.erb
+++ b/app/views/links/_link_fields.html.erb
@@ -1,0 +1,16 @@
+<div class="nested-fields mb-4 p-4 border border-gray-200 rounded-lg dark:border-gray-700">
+  <div class="grid gap-4 mb-4 grid-cols-2">
+    <div>
+      <%= f.label :name, 'Название', class: 'block mb-2 text-sm font-medium text-gray-900 dark:text-white' %>
+      <%= f.text_field :name, class: 'bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500' %>
+    </div>
+    <div>
+      <%= f.label :url, 'Ссылка', class: 'block mb-2 text-sm font-medium text-gray-900 dark:text-white' %>
+      <%= f.text_field :url, class: 'bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500' %>
+    </div>
+  </div>
+  
+  <%= link_to 'Удалить ссылку', '#', class: 'remove_fields inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-red-700 rounded-lg hover:bg-red-800 focus:ring-4 focus:outline-none focus:ring-red-300 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-800' %>
+  
+  <%= f.hidden_field :_destroy %>
+</div>

--- a/app/views/links/destroy.turbo_stream.erb
+++ b/app/views/links/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove "link-#{@link.id}" %>

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -20,6 +20,25 @@
     <%= f.text_area :body, rows: 6, class: "block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 focus-ring dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: "Describe your question in detail..." %>
   </div>
 
+  <div class="links">
+    <h3 class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Ссылки</h3>
+    
+    <div id="links">
+      <%= f.fields_for :links do |link| %>
+        <%= render 'links/link_fields', f: link %>
+      <% end %>
+    </div>
+    
+    <div class="mt-3">
+      <%= link_to 'Добавить ссылку', '#', 
+          class: 'add_fields text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800 focus-ring',
+          data: { 
+            id: 'new_link_fields', 
+            fields_template: fields_for('question[links_attributes][new_link_fields]', Link.new, child_index: 'new_link_fields') { |builder| render('links/link_fields', f: builder) }.gsub('\n', '') 
+          } %>
+    </div>
+  </div>
+
   <div>
     <%= f.label :files, class: "block mb-2 text-sm font-medium text-gray-900 dark:text-white" %>
     <%= f.file_field :files, multiple: true, direct_upload: true, class: "block w-full text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 dark:text-gray-400 focus:outline-none dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400" %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -13,6 +13,15 @@
         <%= simple_format(@question.body) %>
       </div>
       
+      <% if @question.links.present? %>
+      <div class="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+        <h3 class="text-base font-medium mb-3 text-gray-900 dark:text-white">Ссылки:</h3>
+        <div class="links">
+          <%= render @question.links %>
+        </div>
+      </div>
+      <% end %>
+      
       <% if @question.files.attached? %>
       <div class="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
         <h3 class="text-base font-medium mb-3 text-gray-900 dark:text-white">Attached Files:</h3>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,6 +1,7 @@
 # Pin npm packages by running ./bin/importmap
 
-pin "application"
+pin "application", preload: true
+pin "@nathanvda/cocoon", to: "https://ga.jspm.io/npm:@nathanvda/cocoon@1.2.14/cocoon.js"
 pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   root "questions#index"
 
   resources :attachments, only: :destroy
+  resources :links, only: :destroy
 
   resources :questions, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     resources :answers, only: [ :create, :update, :destroy ], shallow: true do

--- a/db/migrate/20250801194948_add_name_to_links.rb
+++ b/db/migrate/20250801194948_add_name_to_links.rb
@@ -1,0 +1,5 @@
+class AddNameToLinks < ActiveRecord::Migration[8.0]
+  def change
+    add_column :links, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_28_044311) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_01_194948) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -48,6 +48,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_28_044311) do
     t.boolean "best", default: false
     t.index ["question_id"], name: "index_answers_on_question_id"
     t.index ["user_id"], name: "index_answers_on_user_id"
+  end
+
+  create_table "links", force: :cascade do |t|
+    t.string "url", null: false
+    t.string "linkable_type", null: false
+    t.integer "linkable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "name"
+    t.index ["linkable_type", "linkable_id"], name: "index_links_on_linkable"
+    t.index ["linkable_type", "linkable_id"], name: "index_links_on_linkable_type_and_linkable_id"
   end
 
   create_table "questions", force: :cascade do |t|

--- a/spec/factories/links.rb
+++ b/spec/factories/links.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :link do
+    name { "Тестовая ссылка" }
+    url { "https://example.com" }
+    association :linkable, factory: :question
+  end
+end

--- a/spec/features/answers_links_spec.rb
+++ b/spec/features/answers_links_spec.rb
@@ -1,0 +1,147 @@
+require 'rails_helper'
+
+feature 'User can add links to answer', %q{
+  In order to provide additional info to my answer
+  As an answer's author
+  I'd like to be able to add links
+} do
+
+  given(:user) { create(:user) }
+  given!(:question) { create(:question) }
+  given(:gist_url) { 'https://gist.github.com/username/12345' }
+  given(:regular_url) { 'https://google.com' }
+
+  describe 'User adds links when creates answer' do
+    background do
+      sign_in(user)
+      visit question_path(question)
+    end
+
+    scenario 'User adds link when creates answer', js: true do
+      fill_in 'Ваш ответ', with: 'Текст ответа'
+
+      click_on 'Добавить ссылку'
+
+      within '.nested-fields' do
+        fill_in 'Название', with: 'Мой гист'
+        fill_in 'Ссылка', with: gist_url
+      end
+
+      click_on 'Создать ответ'
+
+      within '.answers' do
+        expect(page).to have_link 'Мой гист', href: gist_url
+      end
+    end
+
+    scenario 'User adds multiple links when creates answer', js: true do
+      fill_in 'Ваш ответ', with: 'Текст ответа'
+
+      click_on 'Добавить ссылку'
+
+      within all('.nested-fields')[0] do
+        fill_in 'Название', with: 'Мой гист'
+        fill_in 'Ссылка', with: gist_url
+      end
+
+      click_on 'Добавить ссылку'
+
+      within all('.nested-fields')[1] do
+        fill_in 'Название', with: 'Google'
+        fill_in 'Ссылка', with: regular_url
+      end
+
+      click_on 'Создать ответ'
+
+      within '.answers' do
+        expect(page).to have_link 'Мой гист', href: gist_url
+        expect(page).to have_link 'Google', href: regular_url
+      end
+    end
+
+    scenario 'User tries to add invalid link when creates answer', js: true do
+      fill_in 'Ваш ответ', with: 'Текст ответа'
+
+      click_on 'Добавить ссылку'
+
+      within '.nested-fields' do
+        fill_in 'Название', with: 'Неверная ссылка'
+        fill_in 'Ссылка', with: 'invalid-url'
+      end
+
+      click_on 'Создать ответ'
+
+      expect(page).to have_content 'Ссылки url должен быть валидным URL, начинающимся с http:// или https://'
+    end
+  end
+
+  describe 'User adds links when edits answer' do
+    given!(:answer) { create(:answer, question: question, user: user) }
+
+    background do
+      sign_in(user)
+      visit question_path(question)
+      click_on 'Редактировать'
+    end
+
+    scenario 'User adds link when edits answer', js: true do
+      within "#edit-answer-#{answer.id}" do
+        click_on 'Добавить ссылку'
+
+        within '.nested-fields' do
+          fill_in 'Название', with: 'Мой гист'
+          fill_in 'Ссылка', with: gist_url
+        end
+
+        click_on 'Сохранить'
+      end
+
+      expect(page).to have_link 'Мой гист', href: gist_url
+    end
+  end
+
+  describe 'User deletes links from answer' do
+    given!(:answer) { create(:answer, question: question, user: user) }
+    given!(:link) { create(:link, linkable: answer, name: 'Google', url: regular_url) }
+
+    scenario 'User deletes link from answer', js: true do
+      sign_in(user)
+      visit question_path(question)
+
+      expect(page).to have_link 'Google', href: regular_url
+
+      click_on 'Редактировать'
+
+      within "#edit-answer-#{answer.id}" do
+        click_on 'Удалить ссылку'
+        click_on 'Сохранить'
+      end
+
+      expect(page).to_not have_link 'Google', href: regular_url
+    end
+
+    scenario 'Non-author cannot delete link from answer' do
+      other_user = create(:user)
+      sign_in(other_user)
+      visit question_path(question)
+
+      expect(page).to have_link 'Google', href: regular_url
+      expect(page).to_not have_link 'Редактировать'
+    end
+  end
+
+  describe 'GitHub Gist embedding' do
+    given!(:answer) { create(:answer, question: question, user: user) }
+    given!(:gist_link) { create(:link, linkable: answer, name: 'Мой гист', url: gist_url) }
+
+    scenario 'Gist link is embedded', js: true do
+      sign_in(user)
+      visit question_path(question)
+
+      within '.answers' do
+        expect(page).to have_link 'Мой гист', href: gist_url
+        expect(page).to have_css('.gist-embed')
+      end
+    end
+  end
+end

--- a/spec/features/links_spec.rb
+++ b/spec/features/links_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+feature 'User can add links to question', %q{
+  In order to provide additional info to my question
+  As an question's author
+  I'd like to be able to add links
+} do
+
+  given(:user) { create(:user) }
+  given(:gist_url) { 'https://gist.github.com/example/123456789' }
+  given(:simple_url) { 'https://example.com' }
+
+  scenario 'User adds links when asks question', js: true do
+    sign_in(user)
+    visit new_question_path
+
+    fill_in 'Title', with: 'Test question'
+    fill_in 'Body', with: 'text text text'
+
+    click_on 'Добавить ссылку'
+
+    within all('.nested-fields').first do
+      fill_in 'Название', with: 'My gist'
+      fill_in 'Ссылка', with: gist_url
+    end
+
+    click_on 'Добавить ссылку'
+
+    within all('.nested-fields').last do
+      fill_in 'Название', with: 'My link'
+      fill_in 'Ссылка', with: simple_url
+    end
+
+    click_on 'Ask'
+
+    expect(page).to have_link 'My link', href: simple_url
+    expect(page).to have_content 'My gist'
+  end
+end
+
+feature 'User can add links to answer', %q{
+  In order to provide additional info to my answer
+  As an answer's author
+  I'd like to be able to add links
+} do
+
+  given(:user) { create(:user) }
+  given(:question) { create(:question) }
+  given(:gist_url) { 'https://gist.github.com/example/123456789' }
+  given(:simple_url) { 'https://example.com' }
+
+  scenario 'User adds links when creates answer', js: true do
+    sign_in(user)
+    visit question_path(question)
+
+    fill_in 'Body', with: 'My answer'
+
+    click_on 'Добавить ссылку'
+
+    within all('.nested-fields').first do
+      fill_in 'Название', with: 'My gist'
+      fill_in 'Ссылка', with: gist_url
+    end
+
+    click_on 'Добавить ссылку'
+
+    within all('.nested-fields').last do
+      fill_in 'Название', with: 'My link'
+      fill_in 'Ссылка', with: simple_url
+    end
+
+    click_on 'Answer'
+
+    within '.answers' do
+      expect(page).to have_link 'My link', href: simple_url
+      expect(page).to have_content 'My gist'
+    end
+  end
+end
+
+feature 'User can delete links', %q{
+  In order to remove unnecessary links
+  As an author of question or answer
+  I'd like to be able to delete links
+} do
+
+  given(:user) { create(:user) }
+  given(:another_user) { create(:user) }
+  given(:question) { create(:question, user: user) }
+  given!(:link) { create(:link, linkable: question) }
+
+  scenario 'Author deletes link from question', js: true do
+    sign_in(user)
+    visit question_path(question)
+
+    expect(page).to have_link link.name, href: link.url
+
+    within '.links' do
+      click_on '✕'
+    end
+
+    expect(page).to_not have_link link.name, href: link.url
+  end
+
+  scenario 'Non-author cannot delete link', js: true do
+    sign_in(another_user)
+    visit question_path(question)
+
+    expect(page).to have_link link.name, href: link.url
+    expect(page).to_not have_link '✕'
+  end
+
+  scenario 'Unauthenticated user cannot delete link' do
+    visit question_path(question)
+
+    expect(page).to have_link link.name, href: link.url
+    expect(page).to_not have_link '✕'
+  end
+end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Answer, type: :model do
   describe 'associations' do
     it { should belong_to(:question) }
     it { should belong_to(:user) }
+    it { should have_many(:links).dependent(:destroy) }
+    it { should accept_nested_attributes_for(:links).allow_destroy(true) }
   end
 
   describe 'validations' do

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Link, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe Question, type: :model do
   describe 'associations' do
     it { should have_many(:answers).dependent(:destroy) }
+    it { should have_many(:links).dependent(:destroy) }
+    it { should accept_nested_attributes_for(:links).allow_destroy(true) }
     it { should belong_to(:user) }
     it { should have_one(:best_answer).class_name('Answer').conditions(best: true) }
   end

--- a/spec/requests/links_spec.rb
+++ b/spec/requests/links_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe 'Links', type: :request do
+  describe 'DELETE /links/:id' do
+    let(:user) { create(:user) }
+    let(:another_user) { create(:user) }
+    let(:question) { create(:question, user: user) }
+    let!(:link) { create(:link, linkable: question) }
+
+    context 'when user is authenticated' do
+      context 'and is the author of the linkable' do
+        before { sign_in(user) }
+
+        it 'deletes the link' do
+          expect do
+            delete link_path(link), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+          end.to change(Link, :count).by(-1)
+        end
+
+        it 'returns turbo stream response' do
+          delete link_path(link), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+          expect(response.media_type).to eq 'text/vnd.turbo-stream.html'
+        end
+      end
+
+      context 'and is not the author of the linkable' do
+        before { sign_in(another_user) }
+
+        it 'does not delete the link' do
+          expect do
+            delete link_path(link), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+          end.not_to change(Link, :count)
+        end
+
+        it 'returns forbidden status' do
+          delete link_path(link), headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    context 'when user is not authenticated' do
+      it 'does not delete the link' do
+        expect do
+          delete link_path(link)
+        end.not_to change(Link, :count)
+      end
+
+      it 'redirects to login page' do
+        delete link_path(link)
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Пользователь может добавлять несколько ссылок к вопросу или ответу. 
Для реализации можно использовать gem cocoon ([github.com](https://github.com/nathanvda/cocoon)).
   - При добавлении ссылки валидировать ее на формат URL, если ссылка не валидная, не создавать объект и выводить сообщение об ошибке валидации
   - Если дана ссылка на gist, то выводить сразу gist, а не просто ссылку.
- Автор может удалить ссылки у своего вопроса/ответа
- При редактировании  вопроса/ответа автор может добавить новые ссылки 


2. Реализовать награждение за лучший ответ:
- При создании вопроса, пользователь может также создать награду за лучший ответ, которую получит отвечающий
  - награда - это название и прикрепленное пользователем изображение
- Когда автор вопроса выбирает лучший ответ, пользователь, давший лучший ответ получает назначенную награду
- Пользователь может просматривать полученные им награды
  - При этом он видит заголовок вопроса, изображение награды и ее название